### PR TITLE
Email verification

### DIFF
--- a/HIV_System_API_Backend/Controllers/AccountController.cs
+++ b/HIV_System_API_Backend/Controllers/AccountController.cs
@@ -1,6 +1,7 @@
 ﻿using Azure;
 using HIV_System_API_BOs;
 using HIV_System_API_DTOs.AccountDTO;
+using HIV_System_API_DTOs.EmailDTO;
 using HIV_System_API_DTOs.PatientDTO;
 using HIV_System_API_Services.Implements;
 using HIV_System_API_Services.Interfaces;
@@ -11,11 +12,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using static Org.BouncyCastle.Crypto.Engines.SM2Engine;
 
 namespace HIV_System_API_Backend.Controllers
 {
@@ -25,10 +28,15 @@ namespace HIV_System_API_Backend.Controllers
     {
         private IAccountService _accountService;
         private readonly IConfiguration _configuration;
-        public AccountController( IConfiguration configuration)
+        private readonly IEmailSender _emailSender;
+        private readonly IVerificationCodeService _verificationService;
+
+        public AccountController(IConfiguration configuration, IMemoryCache memoryCache)
         {
             _configuration = configuration;
-            _accountService = new AccountService();
+            _accountService = new AccountService(memoryCache);
+            _emailSender = new EmailSender(configuration);
+            _verificationService = new VerificationCodeService(memoryCache);
         }
 
         [HttpGet("GetAllAccounts")]
@@ -56,6 +64,10 @@ namespace HIV_System_API_Backend.Controllers
             if (account == null)
             {
                 return NotFound("Account not found or invalid credentials.");
+            }
+            if (account.IsActive == false)
+            {
+                return Unauthorized("Please verify your email before logging in or contact support if you have verified.");
             }
 
             var tokenString = GenerateJSONWebToken(account);
@@ -108,7 +120,7 @@ namespace HIV_System_API_Backend.Controllers
         }
 
         [HttpGet("GetAccountById/{id}")]
-        [Authorize(Roles ="1, 5")]
+        [Authorize(Roles = "1, 5")]
         public async Task<IActionResult> GetAccountById(int id)
         {
             var account = await _accountService.GetAccountByIdAsync(id);
@@ -210,33 +222,29 @@ namespace HIV_System_API_Backend.Controllers
             }
         }
 
-        [HttpPost("CreatePatientAccount")]
+        [HttpPost("RegisterPatient")]
         [AllowAnonymous]
-        public async Task<IActionResult> CreatePatientAccount([FromBody] PatientAccountRequestDTO request)
+        public async Task<IActionResult> RegisterPatient([FromBody] PatientAccountRequestDTO request)
         {
-            if (request == null ||
-                string.IsNullOrWhiteSpace(request.AccUsername) ||
-                string.IsNullOrWhiteSpace(request.AccPassword))
-            {
-                return BadRequest("Username and password are required.");
-            }
+            if (request == null)
+                return BadRequest("Registration details are required.");
 
             try
             {
-                var createdPatient = await _accountService.CreatePatientAccountAsync(request);
-                if (createdPatient == null)
-                {
-                    return StatusCode(StatusCodes.Status500InternalServerError, "Patient account could not be created.");
-                }
-                return CreatedAtAction(nameof(GetAccountById), new { id = createdPatient.AccId }, createdPatient);
+                var (verificationCode, email) = await _accountService.InitiatePatientRegistrationAsync(request);
+
+                // Send verification email
+                await SendVerificationEmail(email, verificationCode);
+
+                return Ok(new { message = "Registration initiated. Please check your email for verification code." });
             }
-            catch (DbUpdateException ex)
+            catch (InvalidOperationException ex)
             {
-                return Conflict($"Patient account creation failed: {ex.InnerException}");
+                return Conflict(ex.Message);
             }
             catch (Exception ex)
             {
-                return StatusCode(StatusCodes.Status500InternalServerError, $"An error occurred: {ex.InnerException}");
+                return StatusCode(StatusCodes.Status500InternalServerError, $"An error occurred: {ex.Message}");
             }
         }
         [HttpPut("UpdatePatientProfile")]
@@ -297,6 +305,123 @@ namespace HIV_System_API_Backend.Controllers
             {
                 return StatusCode(StatusCodes.Status500InternalServerError, $"An error occurred: {ex.Message}");
             }
+        }
+
+        [HttpPost("resend-verification")]
+        [AllowAnonymous]
+        public async Task<IActionResult> ResendVerificationCode([FromBody] ResendVerificationRequest request)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(request.Email))
+                    return BadRequest(new { message = "Email is required" });
+
+                // Verify if there's a pending registration by checking with account service
+                var (isValid, message) = await _accountService.HasPendingRegistrationAsync(request.Email);
+                if (!isValid)
+                    return BadRequest(new { message });
+
+                // Generate new verification code
+                var code = _verificationService.GenerateCode(request.Email);
+                await SendVerificationEmail(request.Email, code);
+
+                return Ok(new { message = "New verification code has been sent" });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError,
+                    new { message = $"An error occurred: {ex.Message}" });
+            }
+        }
+
+        [HttpPost("verify-registration")]
+        [AllowAnonymous]
+        public async Task<IActionResult> VerifyRegistration([FromBody] EmailVerificationRequest request)
+        {
+            try
+            {
+                var account = await _accountService.VerifyEmailAndCreateAccountAsync(request.Email, request.Code);
+
+                // If we got here, the account was created successfully
+                // Generate JWT token for immediate login
+                var token = GenerateJSONWebToken(account);
+
+                // Create a simplified response object to avoid serialization issues
+                var response = new
+                {
+                    message = "Account created successfully",
+                    token = token,
+                    account = new
+                    {
+                        account.AccId,
+                        account.AccUsername,
+                        account.Email,
+                        account.Fullname,
+                        account.Dob,
+                        account.Gender,
+                        account.Roles,
+                        account.IsActive
+                    }
+                };
+
+                return Ok(response);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                // Even if account creation succeeded, there might be an issue with response generation
+                // Log the error but still return success if we can verify the account exists
+                try
+                {
+                    var createdAccount = await _accountService.GetAccountByEmailAsync(request.Email);
+                    if (createdAccount != null && createdAccount.IsActive == true)
+                    {
+                        var token = GenerateJSONWebToken(createdAccount);
+                        var response = new
+                        {
+                            message = "Account created successfully",
+                            token = token,
+                            account = new
+                            {
+                                createdAccount.AccId,
+                                createdAccount.AccUsername,
+                                createdAccount.Email,
+                                createdAccount.Fullname,
+                                createdAccount.Dob,
+                                createdAccount.Gender,
+                                createdAccount.Roles,
+                                createdAccount.IsActive
+                            }
+                        };
+                        return Ok(response);
+                    }
+                }
+                catch
+                {
+                    // If the fallback fails, then return the 500 error
+                }
+
+                return StatusCode(StatusCodes.Status500InternalServerError,
+                    new { message = "Account was created but there was an error generating the response." });
+            }
+        }
+
+        private async Task SendVerificationEmail(string email, string code)
+        {
+            var emailContent = $@"
+            <h2>Welcome to HIV System</h2>
+            <p>Your verification code is: <strong>{code}</strong></p>
+            <p>This code will expire in 4 minutes.</p>
+            <p>If the code expires, you can request a new one through the application.</p>";
+
+            await _emailSender.SendEmailAsync(
+                email,
+                "Verify Your Email",
+                emailContent
+            );
         }
     }
 }

--- a/HIV_System_API_Backend/Controllers/PatientMedicalRecordController.cs
+++ b/HIV_System_API_Backend/Controllers/PatientMedicalRecordController.cs
@@ -6,6 +6,7 @@ using HIV_System_API_Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using System.Security.Claims;
 
 namespace HIV_System_API_Backend.Controllers
@@ -18,11 +19,11 @@ namespace HIV_System_API_Backend.Controllers
         private readonly IConfiguration _configuration;
         private readonly IAccountService _accountService;
 
-        public PatientMedicalRecordController(IConfiguration configuration)
+        public PatientMedicalRecordController(IConfiguration configuration, IMemoryCache memoryCache)
         {
             _patientMedicalRecordService = new PatientMedicalRecordService();
             _configuration = configuration;
-            _accountService = new AccountService();
+            _accountService = new AccountService(memoryCache);
         }
 
         [HttpGet("GetPatientsMedicalRecord")]

--- a/HIV_System_API_Backend/HIV_System_API_Backend.csproj
+++ b/HIV_System_API_Backend/HIV_System_API_Backend.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.12.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/HIV_System_API_Backend/Program.cs
+++ b/HIV_System_API_Backend/Program.cs
@@ -12,6 +12,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddControllers();
 
+
 // Add JWT Authentication
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -118,6 +119,9 @@ builder.Services.AddScoped<IPatientMedicalRecordService, PatientMedicalRecordSer
 builder.Services.AddScoped<IPatientArvRegimenService, PatientArvRegimenService>();
 builder.Services.AddScoped<IPatientArvMedicationService, PatientArvMedicationService>();
 builder.Services.AddScoped<IMedicalServiceService, MedicalServiceService>();
+builder.Services.AddScoped<IEmailSender, EmailSender>();
+builder.Services.AddMemoryCache();
+builder.Services.AddScoped<IVerificationCodeService, VerificationCodeService>();
 
 // Add CORS policy
 builder.Services.AddCors(options =>

--- a/HIV_System_API_Backend/appsettings.json
+++ b/HIV_System_API_Backend/appsettings.json
@@ -13,5 +13,14 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "HIVSystemDatabase": "Server=localhost;Database=HIV_SYSTEM_API;Uid=sa;Pwd=12345;TrustServerCertificate=True"
+  },
+  
+  "SmtpSettings": {
+    "Server": "smtp.gmail.com",
+    "Port": 587,
+    "SenderName": "HIV System",
+    "SenderEmail": "systemhiv5@gmail.com",
+    "Username": "systemhiv5@gmail.com",
+    "Password": "qtuk msnr zwbx svor"
   }
 }

--- a/HIV_System_API_DAOs/Interfaces/IAccountDAO.cs
+++ b/HIV_System_API_DAOs/Interfaces/IAccountDAO.cs
@@ -20,5 +20,7 @@ namespace HIV_System_API_DAOs.Interfaces
         Task<bool> IsEmailUsedAsync(string mail);
         Task<Account> UpdateAccountProfileAsync(int id, Account updatedAccount);
         Task<Account?> GetAccountByUsernameAsync(string username);
+        Task<Account?> GetAccountByEmailAsync(string email);
+        Task<Account> UpdateAccountStatusAsync(int id, bool isActive);
     }
 }

--- a/HIV_System_API_DTOs/AccountDTO/PendingPatientRegistrationDTO.cs
+++ b/HIV_System_API_DTOs/AccountDTO/PendingPatientRegistrationDTO.cs
@@ -1,0 +1,12 @@
+namespace HIV_System_API_DTOs.AccountDTO
+{
+    public class PendingPatientRegistrationDTO
+    {
+        public string AccUsername { get; set; } = string.Empty;
+        public string AccPassword { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string? Fullname { get; set; }
+        public DateTime? Dob { get; set; }
+        public bool? Gender { get; set; }
+    }
+}

--- a/HIV_System_API_DTOs/EmailDTO/EmailVerificationRequest.cs
+++ b/HIV_System_API_DTOs/EmailDTO/EmailVerificationRequest.cs
@@ -1,0 +1,8 @@
+namespace HIV_System_API_DTOs.EmailDTO
+{
+    public class EmailVerificationRequest
+    {
+        public string Email { get; set; } = string.Empty;
+        public string Code { get; set; } = string.Empty;
+    }
+}

--- a/HIV_System_API_DTOs/EmailDTO/ResendVerificationRequest.cs
+++ b/HIV_System_API_DTOs/EmailDTO/ResendVerificationRequest.cs
@@ -1,0 +1,7 @@
+namespace HIV_System_API_DTOs.EmailDTO
+{
+    public class ResendVerificationRequest
+    {
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/HIV_System_API_Repositories/Implements/AccountRepo.cs
+++ b/HIV_System_API_Repositories/Implements/AccountRepo.cs
@@ -27,6 +27,11 @@ namespace HIV_System_API_Repositories.Implements
             return await AccountDAO.Instance.DeleteAccountAsync(accId);
         }
 
+        public Task<Account?> GetAccountByEmailAsync(string email)
+        {
+            return AccountDAO.Instance.GetAccountByEmailAsync(email);
+        }
+
         public async Task<Account?> GetAccountByIdAsync(int accId)
         {
             return await AccountDAO.Instance.GetAccountByIdAsync(accId);
@@ -60,6 +65,11 @@ namespace HIV_System_API_Repositories.Implements
         public Task<Account> UpdateAccountProfileAsync(int id, Account updatedAccount)
         {
             return AccountDAO.Instance.UpdateAccountProfileAsync(id, updatedAccount);
+        }
+
+        public Task<Account> UpdateAccountStatusAsync(int id, bool isActive)
+        {
+            return AccountDAO.Instance.UpdateAccountStatusAsync(id, isActive);
         }
     }
 }

--- a/HIV_System_API_Repositories/Interfaces/IAccountRepo.cs
+++ b/HIV_System_API_Repositories/Interfaces/IAccountRepo.cs
@@ -21,5 +21,7 @@ namespace HIV_System_API_Repositories.Interfaces
         Task<bool> IsEmailUsedAsync(string mail);
         Task<Account> UpdateAccountProfileAsync(int id, Account updatedAccount);
         Task<Account?> GetAccountByUsernameAsync(string username);
+        Task<Account?> GetAccountByEmailAsync(string email);
+        Task<Account> UpdateAccountStatusAsync(int id, bool isActive);
     }
 }

--- a/HIV_System_API_Services/HIV_System_API_Services.csproj
+++ b/HIV_System_API_Services/HIV_System_API_Services.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\HIV_System_API_Repositories\HIV_System_API_Repositories.csproj" />
   </ItemGroup>
 

--- a/HIV_System_API_Services/Implements/AccountService.cs
+++ b/HIV_System_API_Services/Implements/AccountService.cs
@@ -5,6 +5,7 @@ using HIV_System_API_DTOs.PatientMedicalRecordDTO;
 using HIV_System_API_Repositories.Implements;
 using HIV_System_API_Repositories.Interfaces;
 using HIV_System_API_Services.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,11 +17,18 @@ namespace HIV_System_API_Services.Implements
     public class AccountService : IAccountService
     {
         private readonly IAccountRepo _accountRepo;
+        private readonly IVerificationCodeService _verificationService;
+        private readonly IMemoryCache _memoryCache;
+        private const int PENDING_REGISTRATION_EXPIRY_MINUTES = 30;
 
-        public AccountService()
+        public AccountService(IMemoryCache memoryCache)
         {
             _accountRepo = new AccountRepo();
+            _verificationService = new VerificationCodeService(memoryCache);
+            _memoryCache = memoryCache;
         }
+
+
 
         private Account MapToEntity(AccountRequestDTO dto)
         {
@@ -100,12 +108,12 @@ namespace HIV_System_API_Services.Implements
             if (updatedAccount == null)
                 throw new ArgumentNullException(nameof(updatedAccount));
             //check authorization
-            if(updatedAccount.Roles != 1)
+            if (updatedAccount.Roles != 1)
             {
-                if(updatedAccount.Roles == 4 && updatedAccount.Roles == 5)
+                if (updatedAccount.Roles == 4 && updatedAccount.Roles == 5)
                 {
                     var currentAccount = await _accountRepo.GetAccountByIdAsync(id);
-                    if(currentAccount?.Roles == 1)
+                    if (currentAccount?.Roles == 1)
                         throw new UnauthorizedAccessException("You do not have permission to update this account.");
                 }
             }
@@ -134,7 +142,7 @@ namespace HIV_System_API_Services.Implements
             return MapToResponseDTO(updatedEntity);
         }
 
-        public async Task<PatientResponseDTO> CreatePatientAccountAsync(PatientAccountRequestDTO patient)
+        internal async Task<PatientResponseDTO> CreatePatientAccountAsync(PatientAccountRequestDTO patient)
         {
             if (patient == null)
                 throw new ArgumentNullException(nameof(patient));
@@ -263,6 +271,116 @@ namespace HIV_System_API_Services.Implements
             }
 
             return MapToResponseDTO(updatedAccount);
+        }
+
+        
+
+        public async Task<AccountResponseDTO?> GetAccountByEmailAsync(string email)
+        {
+            if (string.IsNullOrWhiteSpace(email))
+                throw new ArgumentNullException(nameof(email));
+
+            var account = await _accountRepo.GetAccountByEmailAsync(email);
+            if (account == null)
+                return null;
+
+            return MapToResponseDTO(account);
+        }
+
+        public async Task<(string verificationCode, string email)> InitiatePatientRegistrationAsync(PatientAccountRequestDTO request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            if (string.IsNullOrWhiteSpace(request.AccUsername))
+                throw new ArgumentException("Username is required");
+            if (string.IsNullOrWhiteSpace(request.AccPassword))
+                throw new ArgumentException("Password is required");
+            if (string.IsNullOrWhiteSpace(request.Email))
+                throw new ArgumentException("Email is required");
+
+            // Check for existing account
+            var existingAccount = await _accountRepo.GetAccountByLoginAsync(request.AccUsername, request.AccPassword);
+            if (existingAccount != null)
+                throw new InvalidOperationException("Account already exists");
+
+            if (await _accountRepo.IsEmailUsedAsync(request.Email))
+                throw new InvalidOperationException($"Email '{request.Email}' is already in use");
+
+            // Store the registration request in cache
+            var pendingRegistration = new PendingPatientRegistrationDTO
+            {
+                AccUsername = request.AccUsername,
+                AccPassword = request.AccPassword,
+                Email = request.Email,
+                Fullname = request.Fullname,
+                Dob = request.Dob,
+                Gender = request.Gender
+            };
+
+            var cacheOptions = new MemoryCacheEntryOptions()
+                .SetAbsoluteExpiration(TimeSpan.FromMinutes(PENDING_REGISTRATION_EXPIRY_MINUTES));
+
+            var verificationCode = _verificationService.GenerateCode(request.Email);
+            _memoryCache.Set($"pending_registration_{request.Email}", pendingRegistration, cacheOptions);
+
+            return (verificationCode, request.Email);
+        }
+
+        public async Task<AccountResponseDTO> VerifyEmailAndCreateAccountAsync(string email, string code)
+        {
+            if (!_verificationService.VerifyCode(email, code))
+                throw new InvalidOperationException("Invalid or expired verification code");
+
+            // Retrieve pending registration
+            var cacheKey = $"pending_registration_{email}";
+            if (!_memoryCache.TryGetValue(cacheKey, out PendingPatientRegistrationDTO? pendingRegistration))
+                throw new InvalidOperationException("No pending registration found or registration expired");
+
+            _memoryCache.Remove(cacheKey);
+
+            // Create the patient account
+            var patientRequest = new PatientAccountRequestDTO
+            {
+                AccUsername = pendingRegistration.AccUsername,
+                AccPassword = pendingRegistration.AccPassword,
+                Email = pendingRegistration.Email,
+                Fullname = pendingRegistration.Fullname,
+                Dob = pendingRegistration.Dob,
+                Gender = pendingRegistration.Gender
+            };
+
+            var patientResponse = await CreatePatientAccountAsync(patientRequest);
+
+            // The account is created with IsActive = true since it's already verified
+            var account = await _accountRepo.GetAccountByIdAsync(patientResponse.AccId);
+            if (account != null)
+            {
+                account.IsActive = true;
+                await _accountRepo.UpdateAccountStatusAsync(account.AccId, true);
+            }
+
+            return patientResponse.Account ?? throw new InvalidOperationException("Failed to create account");
+        }
+
+        public async Task<(bool isValid, string message)> HasPendingRegistrationAsync(string email)
+        {
+            // Use the same key pattern as used in InitiatePatientRegistrationAsync
+            var pendingRegistration = _memoryCache.Get<PendingPatientRegistrationDTO>($"pending_registration_{email}");
+
+            if (pendingRegistration == null)
+                return (false, "No pending registration found for this email");
+
+            // Check if there's already an account with this email
+            var existingAccount = await GetAccountByEmailAsync(email);
+            if (existingAccount != null)
+            {
+                if (existingAccount.IsActive == true)
+                    return (false, "Account is already verified");
+                return (true, ""); // Account exists but not verified
+            }
+
+            return (true, ""); // Pending registration exists
         }
     }
 }

--- a/HIV_System_API_Services/Implements/EmailSender.cs
+++ b/HIV_System_API_Services/Implements/EmailSender.cs
@@ -1,0 +1,36 @@
+﻿using HIV_System_API_Services.Interfaces;
+using Microsoft.Extensions.Configuration;
+using MailKit.Net.Smtp;
+using MimeKit;
+
+namespace HIV_System_API_Services.Implements
+{
+    public class EmailSender : IEmailSender
+    {
+        private readonly IConfiguration _config;
+
+        public EmailSender(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public async Task SendEmailAsync(string recipientEmail, string subject, string htmlContent)
+        {
+            var email = new MimeMessage();
+            email.From.Add(new MailboxAddress(_config["SmtpSettings:SenderName"], _config["SmtpSettings:SenderEmail"]));
+            email.To.Add(MailboxAddress.Parse(recipientEmail));
+            email.Subject = subject;
+
+            email.Body = new TextPart(MimeKit.Text.TextFormat.Html)
+            {
+                Text = htmlContent
+            };
+
+            using var smtp = new SmtpClient();
+            await smtp.ConnectAsync(_config["SmtpSettings:Server"], int.Parse(_config["SmtpSettings:Port"]), MailKit.Security.SecureSocketOptions.StartTls);
+            await smtp.AuthenticateAsync(_config["SmtpSettings:Username"], _config["SmtpSettings:Password"]);
+            await smtp.SendAsync(email);
+            await smtp.DisconnectAsync(true);
+        }
+    }
+}

--- a/HIV_System_API_Services/Implements/VerificationCodeService.cs
+++ b/HIV_System_API_Services/Implements/VerificationCodeService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HIV_System_API_Services.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace HIV_System_API_Services.Implements
+{
+    public class VerificationCodeService : IVerificationCodeService
+    {
+        private readonly IMemoryCache _cache;
+        private const int CODE_LENGTH = 6;
+        private static readonly TimeSpan CODE_EXPIRY = TimeSpan.FromMinutes(4);
+
+        public VerificationCodeService(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        public string GenerateCode(string email)
+        {
+            var code = Random.Shared.Next(100000, 999999).ToString("D6");
+            
+            // Store in cache with 4-minute expiration
+            var cacheOptions = new MemoryCacheEntryOptions()
+                .SetAbsoluteExpiration(CODE_EXPIRY);
+            
+            _cache.Set($"verification_code_{email}", code, cacheOptions);
+            
+            return code;
+        }
+
+        public bool VerifyCode(string email, string code)
+        {
+            var cacheKey = $"verification_code_{email}";
+            
+            if (!_cache.TryGetValue(cacheKey, out string? storedCode))
+                return false;
+
+            // Remove the code immediately after verification attempt
+            _cache.Remove(cacheKey);
+
+            return code == storedCode;
+        }
+    }
+}

--- a/HIV_System_API_Services/Interfaces/IAccountService.cs
+++ b/HIV_System_API_Services/Interfaces/IAccountService.cs
@@ -17,8 +17,11 @@ namespace HIV_System_API_Services.Interfaces
         Task<AccountResponseDTO> UpdateAccountByIdAsync(int id, UpdateAccountRequestDTO updatedAccount);
         Task<bool> DeleteAccountAsync(int accId);
         Task<AccountResponseDTO> CreateAccountAsync(AccountRequestDTO account);
-        Task<PatientResponseDTO> CreatePatientAccountAsync(PatientAccountRequestDTO patient);
         Task<AccountResponseDTO> UpdatePatientProfileAsync(int accountId, PatientProfileUpdateDTO profileDTO);
         Task<AccountResponseDTO> UpdateDoctorProfileAsync(int accountId, DoctorProfileUpdateDTO profileDTO);
+        Task<AccountResponseDTO?> GetAccountByEmailAsync(string email);
+        Task<(string verificationCode, string email)> InitiatePatientRegistrationAsync(PatientAccountRequestDTO request);
+        Task<AccountResponseDTO> VerifyEmailAndCreateAccountAsync(string email, string code);
+        Task<(bool isValid, string message)> HasPendingRegistrationAsync(string email);
     }
 }

--- a/HIV_System_API_Services/Interfaces/IEmailSender.cs
+++ b/HIV_System_API_Services/Interfaces/IEmailSender.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HIV_System_API_Services.Interfaces
+{
+    public interface IEmailSender
+    {
+        Task SendEmailAsync(string recipientEmail, string subject, string htmlContent);
+    }
+}

--- a/HIV_System_API_Services/Interfaces/IVerificationCodeService.cs
+++ b/HIV_System_API_Services/Interfaces/IVerificationCodeService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HIV_System_API_Services.Interfaces
+{
+    public interface IVerificationCodeService
+    {
+        string GenerateCode(string email);
+        bool VerifyCode(string email, string code);
+    }
+}


### PR DESCRIPTION
1. Sửa CreatePatientAccount từ public thành internal
2. Thay thế CreatePatientAccount thành Register
3. Add thêm một số thứ để phục vụ cho việc verification(extensions, DTOs, DAO, Service)
4. Cách hoạt động của Email verification: Register Account(Account lúc này chưa được tạo) -> Tạo ra 1 pending request kèm theo 1 email gửi code tới email tạo (pending request sẽ tồn tại trong 30ph và Code sẽ tồn tại trong 4ph) -> Nhập code vào verify -> Đúng thì lúc này account chính thức được tạo, phần response sẽ chưa thông tin và cả token để thuận tiện cho việc đăng nhập, đỡ phải lên login lại. 
(*) Trong trường hợp Code expired, có thể bấm resend, sẽ gửi code mới
(*) Nếu Code chưa expired mà bấm resend thì code mới sẽ overwrite lên code cũ